### PR TITLE
Update API endpoint for GeoIP web service requests

### DIFF
--- a/include/library/Crunchbutton/Geo/Geoip/Web.php
+++ b/include/library/Crunchbutton/Geo/Geoip/Web.php
@@ -13,7 +13,7 @@ class Crunchbutton_Geo_Geoip_Web extends Crunchbutton_Geo_Geoip {
 
 		$ret = array();
 		//b
-		$res = file_get_contents('http://geoip3.maxmind.com/f?l='.$this->getApiKey().'&i='.$ip);
+		$res = file_get_contents('https://geoip.maxmind.com/f?l='.$this->getApiKey().'&i='.$ip);
 		$res = explode(',',$res);
 
 		$ret['countryCode'] = $res[0];		


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)